### PR TITLE
fix the implementation of 404Page when route path is not found

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import Seller from './components/seller/seller';
 import routes from './utils/routes';
 import Navigation from './components/navigation/nav';
 import { isLoggedIn } from './helpers/auth';
+import Page404 from './pages/page404/page404';
 import '../styles/index.css';
 import Changepassword from './pages/accounts/editAccount/changepass';
 
@@ -31,6 +32,7 @@ function App() {
           <Route path="/accounts/*" element={isLoggedIn() ? <Home /> : <Accounts />}></Route>
           <Route path="/edit/password" element={isLoggedIn() ? <Changepassword /> : <Home />} />
           <Route path={routes.sellerListItems} element={<Seller />}></Route>
+          <Route path="*" element={<Page404 />}></Route>
         </Routes>
       </Provider>
     </div>

--- a/src/components/seller/components/sellerItems/sellerItems.tsx
+++ b/src/components/seller/components/sellerItems/sellerItems.tsx
@@ -138,7 +138,9 @@ export default function SellerItems() {
         {errorRefetch && <div className="error">{errorRefetch?.message}</div>}
         {initialData && (
           <div className="listItemsBox" data-testid="box_cardList">
-            {sellerItems.length === 0 && <NotFoundSearch reset={handleResetSearch} />}
+            {sellerItems.length === 0 && (
+              <NotFoundSearch btnText="Reset" component={true} reset={handleResetSearch} />
+            )}
             {sellerItems &&
               sellerItems.length > 0 &&
               sellerItems.map((data) => {

--- a/src/designComponents/notFoundSearch/notFound.stories.tsx
+++ b/src/designComponents/notFoundSearch/notFound.stories.tsx
@@ -8,4 +8,4 @@ export default {
   component: NotFoundSearch,
 };
 
-export const Default = () => <NotFoundSearch reset={reset} />;
+export const Default = () => <NotFoundSearch btnText="Reset" reset={reset} />;

--- a/src/designComponents/notFoundSearch/notFoundSearch.module.scss
+++ b/src/designComponents/notFoundSearch/notFoundSearch.module.scss
@@ -18,19 +18,11 @@
       margin: 0;
       padding: 0;
       background-color: transparent;
-      width: 40%;
+      width: 50%;
       height: fit-content;
       align-items: center;
       @include mq($xlg) {
         gap: 15px;
-      }
-      @include mq($lg) {
-        width: 45%;
-      }
-      @include mq($xls) {
-        width: 60%;
-      }
-      @include mq($xxsh) {
         width: 80%;
       }
       .imageLogo {
@@ -57,7 +49,9 @@
         justify-content: center;
         align-items: center;
         @include h3;
+        font-weight: 600;
         font-family: $interBold;
+        font-family: 'poppins', sans-serif;
       }
       .subTitle {
         width: 100%;
@@ -65,7 +59,8 @@
         justify-content: center;
         align-items: center;
         @include h6;
-        font-family: $interRegular;
+        font-family: $interBold;
+        font-family: 'poppins', sans-serif;
       }
       .btn {
         border-radius: 5px;
@@ -80,15 +75,32 @@
         color: $white;
         @include transition;
         border: none;
+        font-family: $interBold;
+        font-family: 'poppins', sans-serif;
         @include mq($xlg) {
           padding: 0 25px;
         }
         @include mq($lg) {
           padding: 0 20px;
         }
-        &:hover{
-            background-color: darken($color: $lightBlue, $amount: 3);
+        &:hover {
+          background-color: darken($color: $lightBlue, $amount: 3);
         }
+      }
+    }
+    .component {
+      width: 40%;
+      @include mq($xlg) {
+        width: 45%;
+      }
+      @include mq($lg) {
+        width: 45%;
+      }
+      @include mq($xls) {
+        width: 60%;
+      }
+      @include mq($xxsh) {
+        width: 80%;
       }
     }
   }

--- a/src/designComponents/notFoundSearch/notFoundSearch.test.tsx
+++ b/src/designComponents/notFoundSearch/notFoundSearch.test.tsx
@@ -5,7 +5,9 @@ import NotFoundSearch from './notFoundSearch';
 describe('NotFoundSearch', () => {
   it('renders the NotFoundSearch component correctly', () => {
     const resetMock = () => vi.fn();
-    const { getByText, getAllByRole } = render(<NotFoundSearch reset={resetMock} />);
+    const { getByText, getAllByRole } = render(
+      <NotFoundSearch btnText="Reset" reset={resetMock} />
+    );
 
     expect(getByText('Not Found')).toBeInTheDocument();
     expect(
@@ -17,5 +19,22 @@ describe('NotFoundSearch', () => {
     const images = getAllByRole('img');
     expect(images.length).toBeGreaterThan(0);
     expect(getAllByRole('heading', { level: 1 }).length).toBeGreaterThan(0);
+  });
+  it('renders the NotFoundSearch component correctly', () => {
+    const resetMock = () => vi.fn();
+    const { getByText, getAllByRole, getByTestId } = render(
+      <NotFoundSearch btnText="Reset" component={true} reset={resetMock} />
+    );
+    expect(getByText('Not Found')).toBeInTheDocument();
+    expect(
+      getByText('Missed what you are looking for? Don’t worry! You can try again with another way!')
+    ).toBeInTheDocument();
+
+    fireEvent.click(getByText('Reset'));
+    const images = getAllByRole('img');
+    expect(images.length).toBeGreaterThan(0);
+    expect(getAllByRole('heading', { level: 1 }).length).toBeGreaterThan(0);
+    const className = getByTestId('404Page');
+    expect(className.className).toBe('container component');
   });
 });

--- a/src/designComponents/notFoundSearch/notFoundSearch.tsx
+++ b/src/designComponents/notFoundSearch/notFoundSearch.tsx
@@ -2,21 +2,23 @@ import styles from './notFoundSearch.module.scss';
 
 interface resetSearch {
   reset: () => void;
+  btnText: string;
+  component?: boolean;
 }
 export default function NotFoundSearch(props: resetSearch) {
-  const { reset } = props;
+  const { reset, btnText, component } = props;
   return (
     <div className={styles.notFoundSearch}>
-      <div className="container">
+      <div className={component ? 'container component' : 'container'} data-testid="404Page">
         <div className="imageLogo">
-          <img src="./svgs/404Logo.svg" alt="404 Logo" className="logo" />
+          <img src="/svgs/404Logo.svg" alt="404 Logo" className="logo" />
         </div>
         <h1 className="title">Not Found</h1>
         <div className="subTitle">
           Missed what you are looking for? Don’t worry! You can try again with another way!
         </div>
         <button data-testid="testIdResetBtn" className="btn" onClick={reset}>
-          Reset
+          {btnText}
         </button>
       </div>
     </div>

--- a/src/pages/page404/__tests__/page404.test.tsx
+++ b/src/pages/page404/__tests__/page404.test.tsx
@@ -1,0 +1,18 @@
+import { render, fireEvent } from '@testing-library/react';
+import Page404 from '../page404';
+import { MemoryRouter } from 'react-router-dom';
+
+describe('Page404', () => {
+  test('should navigate back when the "Back" button is clicked', () => {
+    const { getByText } = render(
+      <MemoryRouter initialEntries={['*']}>
+        <Page404 />
+      </MemoryRouter>
+    );
+    expect(getByText('Back')).toBeInTheDocument();
+    expect(
+      getByText('Missed what you are looking for? Don’t worry! You can try again with another way!')
+    ).toBeInTheDocument();
+    fireEvent.click(getByText('Back'));
+  });
+});

--- a/src/pages/page404/page404.module.scss
+++ b/src/pages/page404/page404.module.scss
@@ -1,0 +1,11 @@
+@import '../../../styles/variables.scss';
+@import '../../../styles/mixins.scss';
+.page404 {
+  :global {
+    
+    padding: 50px;
+    @include pageSettings;
+    justify-content: center;
+    align-items: center;
+  }
+}

--- a/src/pages/page404/page404.tsx
+++ b/src/pages/page404/page404.tsx
@@ -1,0 +1,20 @@
+import NotFoundSearch from '../../designComponents/notFoundSearch/notFoundSearch';
+import styles from './page404.module.scss';
+import { useNavigate } from 'react-router-dom';
+
+function Page404() {
+  const navigate = useNavigate();
+
+  const handleReturnBack = () => {
+    navigate(-1);
+  };
+  return (
+    <div className={styles.page404}>
+      <div className="homeSlides" data-testid="home">
+        <NotFoundSearch reset={handleReturnBack} btnText={'Back'} />
+      </div>
+    </div>
+  );
+}
+
+export default Page404;


### PR DESCRIPTION

#### What does this PR do?
Notifies the user if they didn't didn't find what they are looking for
- when a user tries to search for anything that does not exist on our page, they will get this 404m  page
- user has ability to return back where he were before getting 404

#### Description of Task to be completed?
- used react-router dom to get the user back where he was, after getting 404 page

#### How should this be manually tested?
at the `baseUrl/**anything that does not belong to the page routes**`, you will get 404 page

#### What are the relevant pivotal tracker/Trello stories?
This is a fix
