### PR TITLE
feat(authorization): implement role/permission functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import routes from './utils/routes';
 import Navigation from './components/navigation/nav';
 import { isLoggedIn } from './helpers/auth';
 import Page404 from './pages/page404/page404';
+import AssignRole from './pages/role/AssignRole';
 import '../styles/index.css';
 import Changepassword from './pages/accounts/editAccount/changepass';
 import Contact from './pages/contact/contact';
@@ -36,6 +37,7 @@ function App() {
           <Route path={routes.sellerListItems} element={<Seller />}></Route>
           <Route path="*" element={<Page404 />}></Route>
           <Route path="/contact" element={<Contact />}></Route>
+          <Route path="/manage_users" element={<AssignRole />} />
         </Routes>
         <Footer />
       </Provider>

--- a/src/components/navigation/nav.tsx
+++ b/src/components/navigation/nav.tsx
@@ -137,6 +137,12 @@ const Navigation = () => {
                   </li>
                 </Link>
               )}
+              <Link to="/manage_users" className={styles.Link}>
+                <li>
+                  <i className="fa fa-users" aria-hidden="true"></i>
+                  &nbsp;&nbsp;Manage Users
+                </li>
+              </Link>
               <Link to="/" onClick={() => logout()} className={styles.Link}>
                 <li>
                   <FontAwesomeIcon icon="arrow-right-from-bracket" className={`${styles.logout}`} />

--- a/src/pages/role/AssignRole.tsx
+++ b/src/pages/role/AssignRole.tsx
@@ -1,0 +1,173 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { useAppSelector, useAppDispatch } from '../../redux/hooks';
+import { useRef, useState } from 'react';
+import { ToastContainer, toast } from 'react-toastify';
+import { useFetchUsers } from './hooks';
+import { setRole } from './redux/assignRolesSlice';
+
+interface USER {
+  id: string;
+  email: string;
+  username: string;
+  role: string;
+  status: string;
+}
+
+export default function AssignRole() {
+  const [searchTerm, setSearchTerm] = useState('');
+  const data = useFetchUsers();
+  const filteredItems = data.users.filter((item) =>
+    item.username.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+  return (
+    <div className="w-full flex justify-center flex-col items-center pt-12">
+      <ToastContainer />
+      <div className="w-full flex justify-center flex-col items-right px-[3.5%] pb-2">
+        <div className="pb-4 bg-white flex flex-row items-center justify-between p-2">
+          <label htmlFor="table-search" className="sr-only">
+            Search
+          </label>
+          <div className="relative mt-1">
+            <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+              <svg
+                className="w-5 h-5 text-gray-500"
+                aria-hidden="true"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"
+                  clipRule="evenodd"
+                ></path>
+              </svg>
+            </div>
+            <input
+              data-testid="search-role"
+              type="text"
+              id="table-search"
+              className="block p-2 pl-10 pr-20 text-sm text-black border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500"
+              onChange={(e) => setSearchTerm(e.target.value)}
+              value={searchTerm}
+              placeholder="Search for users name"
+            />
+          </div>
+        </div>
+      </div>
+      <div className="relative overflow-auto w-11/12 max-h-[70vh] shadow-md sm:rounded-lg">
+        {data.loading ? (
+          <div className="w-full p-2 text-center">
+            <i className="fa fa-spinner fa-spin text-orange" aria-hidden="true"></i>
+          </div>
+        ) : (
+          <table className=" text-sm text-left w-full text-gray-500">
+            <thead className="text-xs text-black uppercase bg-[#BFC3D1] top-0 sticky border-b">
+              <tr>
+                <th scope="col" className="px-6 py-3">
+                  Email
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  UserName
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  Status
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  Role
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  Change Role
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.users &&
+                filteredItems.map((user, index) => (
+                  <UserRow
+                    key={index}
+                    email={user.email}
+                    role={user.role}
+                    status={user.status}
+                    id={user.id}
+                    username={user.username}
+                  />
+                ))}
+            </tbody>
+          </table>
+        )}
+        {data.error != '' ? <div className="w-full p-2 text-center">{data.error}</div> : ''}
+      </div>
+    </div>
+  );
+}
+
+export function UserRow({ email, username, role, status, id }: USER) {
+  return (
+    <tr data-testid="user-row" className="bg-white border-b hover:bg-gray-50">
+      <th
+        scope="row"
+        className="px-6 py-4  md:py-2 sm-py-2 font-medium text-gray-900 whitespace-nowrap"
+      >
+        {email}
+      </th>
+      <td className="px-6 py-4  md:py-2 sm-py-2 ">{username}</td>
+      <td className="px-6 py-4  md:py-2 sm-py-2 ">
+        <span
+          className={`p-1 rounded-sm  ${
+            status === 'ACTIVE' ? 'text-black bg-green' : 'text-white bg-red'
+          }`}
+        >
+          {status}
+        </span>
+      </td>
+      <td className="px-6 py-4 md:py-2 sm-py-2 ">{role}</td>
+      <td className="px-6 py-4  md:py-2 sm-py-2 whitespace-nowrap">
+        <RoleButtons id={id} />
+      </td>
+    </tr>
+  );
+}
+
+export function RoleButtons({ id }: { id: string }) {
+  const token = useAppSelector((state) => state.token.value) || '';
+  const isRoleSet = useAppSelector((state) => state.setRole);
+  const dispatch = useAppDispatch();
+  const roleRef = useRef<HTMLSelectElement>(null);
+  const handleSubmit = async () => {
+    const rl = roleRef.current?.value;
+    const data: { id: string; role: string; token: string } = {
+      id,
+      role: rl!,
+      token,
+    };
+
+    const response = await dispatch(setRole(data));
+    if (response.meta.requestStatus === 'fulfilled') {
+      window.location.reload();
+    } else if (response.meta.requestStatus === 'rejected') {
+      if (isRoleSet.error !== '') {
+        toast.error(isRoleSet.error);
+      }
+    }
+  };
+
+  return (
+    <div className="font-medium text-orange space-x-2">
+      <select ref={roleRef} name="" className="outline-none rounded-xs" id="">
+        <option value="SELLER" className="p-1">
+          SELLER
+        </option>
+        <option value="ADMIN" className="p-1">
+          ADMIN
+        </option>
+        <option value="BUYER" className="p-1">
+          BUYER
+        </option>
+      </select>
+      <button data-testid="role-btn" onClick={handleSubmit} className="p-1 px-2 bg-translucent">
+        <i className="fa fa-check" aria-hidden="true"></i> Save
+      </button>
+    </div>
+  );
+}

--- a/src/pages/role/__test__/assignrole.test.tsx
+++ b/src/pages/role/__test__/assignrole.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render } from '@testing-library/react';
+import AssignRole, { RoleButtons, UserRow } from '../AssignRole';
+import { vi } from 'vitest';
+import axios from 'axios';
+import { Provider } from 'react-redux';
+import store from '../../../redux/store';
+
+describe('Testing Assign Role Page', () => {
+  test('Testing useRow', () => {
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <UserRow id="1234" email="test email" username="test" role="test" status="ACTIVE" />
+      </Provider>
+    );
+    expect(getByTestId('user-row')).toBeInTheDocument();
+  });
+  test('Testing useRow', () => {
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <UserRow id="1234" email="test email" username="test" role="test" status="INACTIVE" />
+      </Provider>
+    );
+    expect(getByTestId('user-row')).toBeInTheDocument();
+  });
+  test('Testing Buttons click role', () => {
+    const mockPatch = vi.spyOn(axios, 'patch').mockResolvedValueOnce({
+      id: '12345',
+      email: 'e@mail.com',
+      username: 'testing',
+      role: 'Buyer',
+      status: 'ACTIVE',
+    });
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <RoleButtons id="12345" />
+      </Provider>
+    );
+    fireEvent.click(getByTestId('role-btn'));
+    expect(mockPatch).toBeCalled();
+  });
+  test('Testing Buttons click role with error', () => {
+    const mockPatch = vi.spyOn(axios, 'patch').mockRejectedValueOnce({});
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <RoleButtons id="12345" />
+      </Provider>
+    );
+    fireEvent.click(getByTestId('role-btn'));
+    expect(mockPatch).toBeCalled();
+  });
+  test('Testing get users Page with users', () => {
+    const mockGet = vi.spyOn(axios, 'get').mockResolvedValueOnce({
+      data: {
+        users: [
+          {
+            id: '12345',
+            email: 'e@mail.com',
+            username: 'testing',
+            role: 'Buyer',
+            status: 'ACTIVE',
+          },
+          {
+            id: '67890',
+            email: 'another@mail.com',
+            username: 'another',
+            role: 'Seller',
+            status: 'ACTIVE',
+          },
+        ],
+      },
+    });
+    render(
+      <Provider store={store}>
+        <AssignRole />
+      </Provider>
+    );
+    expect(mockGet).toBeCalled();
+  });
+  test('Testing get users Page with 500 Error', () => {
+    const mockGet = vi.spyOn(axios, 'get').mockRejectedValueOnce({
+      response: {
+        status: 500,
+        data: {
+          error: 'Error',
+        },
+      },
+    });
+    render(
+      <Provider store={store}>
+        <AssignRole />
+      </Provider>
+    );
+    expect(mockGet).toBeCalled();
+  });
+  test('Testing get users Page with Error', () => {
+    const mockGet = vi.spyOn(axios, 'get').mockRejectedValueOnce({
+      response: {
+        status: 400,
+        data: {
+          error: 'Error',
+        },
+      },
+    });
+    render(
+      <Provider store={store}>
+        <AssignRole />
+      </Provider>
+    );
+    expect(mockGet).toBeCalled();
+  });
+  test('Testing get users Page with any error', () => {
+    const mockGet = vi.spyOn(axios, 'get').mockRejectedValueOnce({
+      response: {
+        status: 404,
+        data: {
+          error: 'Error',
+        },
+      },
+    });
+    render(
+      <Provider store={store}>
+        <AssignRole />
+      </Provider>
+    );
+    expect(mockGet).toBeCalled();
+  });
+});

--- a/src/pages/role/hooks.tsx
+++ b/src/pages/role/hooks.tsx
@@ -1,0 +1,14 @@
+import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import { useEffect } from 'react';
+import { getUsers } from './redux/assignRolesSlice';
+
+export const useFetchUsers = () => {
+  const token = useAppSelector((state) => state.token.value) || '';
+  const isFetched = useAppSelector((state) => state.getUsers);
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    dispatch(getUsers({ token }));
+  }, [dispatch, token]);
+
+  return isFetched;
+};

--- a/src/pages/role/redux/assignRolesSlice.ts
+++ b/src/pages/role/redux/assignRolesSlice.ts
@@ -1,0 +1,129 @@
+import { PayloadAction, createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+interface USER {
+  id: string;
+  email: string;
+  username: string;
+  role: string;
+  status: string;
+}
+interface INITIAL_STATE {
+  loading: boolean;
+  users: USER[];
+  error: string;
+}
+const initialState: INITIAL_STATE = {
+  loading: false,
+  users: [],
+  error: '',
+};
+
+function rejectWithValue(error: string) {
+  throw new Error(error);
+}
+
+export const getUsers = createAsyncThunk('get/users', async ({ token }: { token: string }) => {
+  return axios
+    .get(`${import.meta.env.VITE_BACKEND_URL}users/all`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    .then((response) => {
+      const usersArr = response.data.users.map((users: USER) => {
+        return {
+          id: users.id,
+          email: users.email,
+          username: users.username,
+          role: users.role,
+          status: users.status,
+        };
+      });
+      return usersArr;
+    })
+    .catch((error) => {
+      switch (error.response.status) {
+        case 500:
+          return rejectWithValue('Internal Error.');
+        case 400:
+          return rejectWithValue('Please Login.');
+        default:
+          return rejectWithValue(error.response.data.error);
+      }
+    });
+});
+
+export const getUsersSlice = createSlice({
+  name: 'fetchUsers',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(getUsers.pending, (state) => {
+      state.loading = true;
+    });
+    builder.addCase(getUsers.fulfilled, (state, action: PayloadAction<USER[]>) => {
+      state.loading = false;
+      state.users = action.payload;
+      state.error = '';
+    });
+    builder.addCase(getUsers.rejected, (state, action) => {
+      state.loading = false;
+      state.error = action.error.message || 'Unknown Error';
+    });
+  },
+});
+
+export const setRole = createAsyncThunk(
+  'patch/users/role',
+  async ({ id, role, token }: { id: string; role: string; token: string }) => {
+    return axios
+      .patch(
+        `${import.meta.env.VITE_BACKEND_URL}users/${id}/role`,
+        { role },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      )
+      .then((response) => {
+        return response.data;
+      })
+      .catch((error) => {
+        switch (error.response.status) {
+          case 500:
+            return rejectWithValue('Internal Error.');
+          case 400:
+            return rejectWithValue('Please Login.');
+          case 401:
+            return rejectWithValue('Unauthorized.');
+          default:
+            return rejectWithValue(error.response.data.error);
+        }
+      });
+  }
+);
+
+export const setRolesSlice = createSlice({
+  name: 'setRole',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(setRole.pending, (state) => {
+      state.loading = true;
+    });
+    builder.addCase(setRole.fulfilled, (state, action: PayloadAction<USER[]>) => {
+      state.loading = false;
+      state.users = action.payload;
+      state.error = '';
+    });
+    builder.addCase(setRole.rejected, (state, action) => {
+      state.loading = false;
+      state.error = action.error.message || 'Unknown Error';
+    });
+  },
+});
+
+export const getUserReducer = getUsersSlice.reducer;
+export const setRoleReducer = setRolesSlice.reducer;

--- a/src/redux/store.tsx
+++ b/src/redux/store.tsx
@@ -19,6 +19,7 @@ import {
   resetPasswordReducer,
   forgotPasswordReducer,
 } from '../pages/accounts/resetPassword/redux/resetPasswordSlice';
+import { getUserReducer, setRoleReducer } from '../pages/role/redux/assignRolesSlice';
 
 const rootReducer = combineReducers({
   auth: authReducer,
@@ -28,6 +29,8 @@ const rootReducer = combineReducers({
   filterCollectionProducts: filterCollectionProductsReducer,
   resetPassword: resetPasswordReducer,
   forgotPassword: forgotPasswordReducer,
+  getUsers: getUserReducer,
+  setRole: setRoleReducer,
 });
 
 const persistConfig = {


### PR DESCRIPTION
#### What does this PR do?

- ensure that an admin can view all accounts.
- ensure that an admin can change a user's role.

#### Description of Task to be completed?

- Admin should be able to assign roles to users by using their email addresses.

#### How should this be manually tested?

- Login as an admin. email: admin101@example.com password: Qwert@12345
- Click the profile icon to access the link to the manager user panel
- Select a different role for a user and click save

#### What are the relevant pivotal tracker/Trello stories?

#185172097
