### PR TITLE
#185172098 Implement disable account functionality

### DIFF
--- a/src/pages/role/AssignRole.tsx
+++ b/src/pages/role/AssignRole.tsx
@@ -3,7 +3,7 @@ import { useAppSelector, useAppDispatch } from '../../redux/hooks';
 import { useRef, useState } from 'react';
 import { ToastContainer, toast } from 'react-toastify';
 import { useFetchUsers } from './hooks';
-import { setRole } from './redux/assignRolesSlice';
+import { setRole, disableAccount } from './redux/assignRolesSlice';
 
 interface USER {
   id: string;
@@ -79,6 +79,9 @@ export default function AssignRole() {
                 <th scope="col" className="px-6 py-3">
                   Change Role
                 </th>
+                <th scope="col" className="px-6 py-3">
+                  Disable Account
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -115,7 +118,7 @@ export function UserRow({ email, username, role, status, id }: USER) {
       <td className="px-6 py-4  md:py-2 sm-py-2 ">
         <span
           className={`p-1 rounded-sm  ${
-            status === 'ACTIVE' ? 'text-black bg-green' : 'text-white bg-red'
+            status === 'ACTIVE' ? 'text-black bg-green' : 'text-black bg-red'
           }`}
         >
           {status}
@@ -124,6 +127,9 @@ export function UserRow({ email, username, role, status, id }: USER) {
       <td className="px-6 py-4 md:py-2 sm-py-2 ">{role}</td>
       <td className="px-6 py-4  md:py-2 sm-py-2 whitespace-nowrap">
         <RoleButtons id={id} />
+      </td>
+      <td className="px-6 py-4  md:py-2 sm-py-2 ">
+        <DisableButtons id={id} status={status} />
       </td>
     </tr>
   );
@@ -167,6 +173,40 @@ export function RoleButtons({ id }: { id: string }) {
       </select>
       <button data-testid="role-btn" onClick={handleSubmit} className="p-1 px-2 bg-translucent">
         <i className="fa fa-check" aria-hidden="true"></i> Save
+      </button>
+    </div>
+  );
+}
+
+export function DisableButtons({ id, status }: { id: string; status: string }) {
+  const token = useAppSelector((state) => state.token.value) || '';
+  const isDisabled = useAppSelector((state) => state.disableAccount);
+  const dispatch = useAppDispatch();
+  const handleSubmit = async () => {
+    const data: { id: string; token: string } = {
+      id,
+      token,
+    };
+
+    const response = await dispatch(disableAccount(data));
+    if (response.meta.requestStatus === 'fulfilled') {
+      window.location.reload();
+    } else if (response.meta.requestStatus === 'rejected') {
+      if (isDisabled.error !== '') {
+        toast.error(isDisabled.error);
+      }
+    }
+  };
+
+  return (
+    <div className="font-medium text-orange space-x-2">
+      <button
+        data-testid="role-btn"
+        onClick={handleSubmit}
+        className="p-1 px-2 bg-translucent"
+        disabled={status === 'INACTIVE'}
+      >
+        <i className="fa-solid fa-xmark"></i>Disable Account
       </button>
     </div>
   );

--- a/src/pages/role/__test__/assignrole.test.tsx
+++ b/src/pages/role/__test__/assignrole.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from '@testing-library/react';
-import AssignRole, { RoleButtons, UserRow } from '../AssignRole';
+import AssignRole, { DisableButtons, RoleButtons, UserRow } from '../AssignRole';
 import { vi } from 'vitest';
 import axios from 'axios';
 import { Provider } from 'react-redux';
@@ -123,5 +123,32 @@ describe('Testing Assign Role Page', () => {
       </Provider>
     );
     expect(mockGet).toBeCalled();
+  });
+
+  test('Testing Buttons disable account', () => {
+    const mockPatch = vi.spyOn(axios, 'patch').mockResolvedValueOnce({
+      id: '12345',
+      email: 'e@mail.com',
+      username: 'testing',
+      role: 'Buyer',
+      status: 'ACTIVE',
+    });
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <DisableButtons id="12345" status="ACTIVE" />
+      </Provider>
+    );
+    fireEvent.click(getByTestId('role-btn'));
+    expect(mockPatch).toBeCalled();
+  });
+  test('Testing Buttons disable account with error', () => {
+    const mockPatch = vi.spyOn(axios, 'patch').mockRejectedValueOnce({});
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <DisableButtons id="123456" status="ACTIVE" />
+      </Provider>
+    );
+    fireEvent.click(getByTestId('role-btn'));
+    expect(mockPatch).toBeCalled();
   });
 });

--- a/src/pages/role/redux/assignRolesSlice.ts
+++ b/src/pages/role/redux/assignRolesSlice.ts
@@ -125,5 +125,55 @@ export const setRolesSlice = createSlice({
   },
 });
 
+export const disableAccountSlice = createSlice({
+  name: 'disableAccount',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(disableAccount.pending, (state) => {
+      state.loading = true;
+    });
+    builder.addCase(disableAccount.fulfilled, (state) => {
+      state.loading = false;
+    });
+    builder.addCase(disableAccount.rejected, (state, action) => {
+      state.loading = false;
+      state.error = action.error.message || 'Unknown Error';
+    });
+  },
+});
+
+export const disableAccount = createAsyncThunk(
+  'users/disable',
+  async ({ id, token }: { id: string; token: string }) => {
+    return axios
+      .patch(
+        `${import.meta.env.VITE_BACKEND_URL}users/disable/${id}`,
+        {},
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      )
+      .then((response) => {
+        return response.data;
+      })
+      .catch((error) => {
+        switch (error.response.status) {
+          case 500:
+            return rejectWithValue('Internal Error.');
+          case 400:
+            return rejectWithValue('Please Login.');
+          case 401:
+            return rejectWithValue('Unauthorized.');
+          default:
+            return rejectWithValue(error.response.data.error);
+        }
+      });
+  }
+);
+
 export const getUserReducer = getUsersSlice.reducer;
 export const setRoleReducer = setRolesSlice.reducer;
+export const disableAccountReducer = disableAccountSlice.reducer;

--- a/src/redux/store.tsx
+++ b/src/redux/store.tsx
@@ -19,7 +19,11 @@ import {
   resetPasswordReducer,
   forgotPasswordReducer,
 } from '../pages/accounts/resetPassword/redux/resetPasswordSlice';
-import { getUserReducer, setRoleReducer } from '../pages/role/redux/assignRolesSlice';
+import {
+  getUserReducer,
+  setRoleReducer,
+  disableAccountReducer,
+} from '../pages/role/redux/assignRolesSlice';
 import addToCartReducer from '../components/cart/redux/addToCartSlice';
 import cartDataReducer from '../components/cart/redux/cartDataSlice';
 import fetchTopProductsReducer from '../components/Product/redux/getTopProductsSlice';
@@ -41,6 +45,7 @@ const rootReducer = combineReducers({
   topProducts: fetchTopProductsReducer,
   getCart: getCartSlice,
   product: productReducer,
+  disableAccount: disableAccountReducer,
 });
 
 const persistConfig = {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,7 @@ export default {
       gray: '#808080',
       fade: '#0000000a',
       red: '#ff0000db',
+      green:'#66FF66',
     },
     screens: {
       tablet: '640px',


### PR DESCRIPTION
## What does this PR do?
ensure that admin can disable a user based on various reasons

## Description of Task to be completed?
Admin dashboard should list all users with the option of disabling accounts
Due to varying reasons e.g fraud, abuse, malicious use or violation of terms of service, admin should be able to disable any user account.

## How should this be manually tested?
Login as a admin
Under menu, Go to manage accounts, click disable account on an account, it's status should immediately be changed to INACTIVE
## Any background context you want to provide?
None
## What are the relevant pivotal tracker/Trello stories?
#185172098